### PR TITLE
Discard master and slave phrasing

### DIFF
--- a/core/controllers/api_mock.py
+++ b/core/controllers/api_mock.py
@@ -34,8 +34,8 @@ class ApiMockController(BaseController):
     def get_monitors(self) -> Dict[str, Any]:
         return self._get_response({
             "BACKGROUND THREAD": [
-                "srv_master_thread loops: 111 srv_active, 0 srv_shutdown, 1606 srv_idle",
-                "srv_master_thread log flush and writes: 222"
+                "srv_main_thread loops: 111 srv_active, 0 srv_shutdown, 1606 srv_idle",
+                "srv_main_thread log flush and writes: 222"
             ],
             "SEMAPHORES": [
                 "OS WAIT ARRAY INFO: reservation count 1212",
@@ -314,7 +314,7 @@ class ApiMockController(BaseController):
                 "<span class='span_number'>1</span>",
                 "<span class='span_number'>1</span>"
             ],
-            "slave_compressed_protocol": [
+            "subordinate_compressed_protocol": [
                 "<span class='span_on_off'>ON</span>",
                 "<span class='span_on_off'>ON</span>"
             ],
@@ -374,7 +374,7 @@ class ApiMockController(BaseController):
                 "<span class='span_normal'>YES</span>",
                 "<span class='span_normal'>YES</span>"
             ],
-            "slave_pending_jobs_size_max": [
+            "subordinate_pending_jobs_size_max": [
                 "<span class='span_number'>16777216</span>",
                 "<span class='span_number'>16777216</span>"
             ],
@@ -390,41 +390,41 @@ class ApiMockController(BaseController):
 
     def get_replication_data(self) -> Dict[str, Any]:
         return self._get_response({
-            "master_important_values": {
+            "main_important_values": {
                 "File": "mysql-bin-log.1",
                 "Position": 12
             },
-            "master_full_log": {
+            "main_full_log": {
                 "File": "mysql-bin-log.31",
                 "Position": 33,
                 "Binlog_Do_DB": "",
                 "Binlog_Ignore_DB": "",
                 "Executed_Gtid_Set": ""
             },
-            "slave_important_values": {
-                "Seconds_Behind_Master": " 0",
-                "Master_Log_File": " master-bin.11",
-                "Read_Master_Log_Pos": " 1307",
-                "Relay_Log_File": " slave-relay-bin.211",
+            "subordinate_important_values": {
+                "Seconds_Behind_Main": " 0",
+                "Main_Log_File": " main-bin.11",
+                "Read_Main_Log_Pos": " 1307",
+                "Relay_Log_File": " subordinate-relay-bin.211",
                 "Relay_Log_Pos": " 1508",
-                "Relay_Master_Log_File": " master-bin.222",
+                "Relay_Main_Log_File": " main-bin.222",
                 "Last_Error": "",
                 "Last_IO_Error": "",
                 "Last_SQL_Error": ""
             },
-            "slave_full_log": {
-                "Slave_IO_State": " Waiting for master to send event",
-                "Master_Host": " localhost",
-                "Master_User": " repl",
-                "Master_Port": " 13000",
+            "subordinate_full_log": {
+                "Subordinate_IO_State": " Waiting for main to send event",
+                "Main_Host": " localhost",
+                "Main_User": " repl",
+                "Main_Port": " 13000",
                 "Connect_Retry": " 60",
-                "Master_Log_File": " master-bin.000002",
-                "Read_Master_Log_Pos": " 1307",
-                "Relay_Log_File": " slave-relay-bin.000003",
+                "Main_Log_File": " main-bin.000002",
+                "Read_Main_Log_Pos": " 1307",
+                "Relay_Log_File": " subordinate-relay-bin.000003",
                 "Relay_Log_Pos": " 1508",
-                "Relay_Master_Log_File": " master-bin.000002",
-                "Slave_IO_Running": " Yes",
-                "Slave_SQL_Running": " Yes",
+                "Relay_Main_Log_File": " main-bin.000002",
+                "Subordinate_IO_Running": " Yes",
+                "Subordinate_SQL_Running": " Yes",
                 "Replicate_Do_DB": "",
                 "Replicate_Ignore_DB": "",
                 "Replicate_Do_Table": "",
@@ -434,44 +434,44 @@ class ApiMockController(BaseController):
                 "Last_Errno": " 0",
                 "Last_Error": "",
                 "Skip_Counter": " 0",
-                "Exec_Master_Log_Pos": " 1307",
+                "Exec_Main_Log_Pos": " 1307",
                 "Relay_Log_Space": " 1858",
                 "Until_Condition": " None",
                 "Until_Log_File": "",
                 "Until_Log_Pos": " 0",
-                "Master_SSL_Allowed": " No",
-                "Master_SSL_CA_File": "",
-                "Master_SSL_CA_Path": "",
-                "Master_SSL_Cert": "",
-                "Master_SSL_Cipher": "",
-                "Master_SSL_Key": "",
-                "Seconds_Behind_Master": " 0",
-                "Master_SSL_Verify_Server_Cert": " No",
+                "Main_SSL_Allowed": " No",
+                "Main_SSL_CA_File": "",
+                "Main_SSL_CA_Path": "",
+                "Main_SSL_Cert": "",
+                "Main_SSL_Cipher": "",
+                "Main_SSL_Key": "",
+                "Seconds_Behind_Main": " 0",
+                "Main_SSL_Verify_Server_Cert": " No",
                 "Last_IO_Errno": " 0",
                 "Last_IO_Error": "",
                 "Last_SQL_Errno": " 0",
                 "Last_SQL_Error": "",
                 "Replicate_Ignore_Server_Ids": "",
-                "Master_Server_Id": " 1",
-                "Master_UUID": " abc-cda ",
-                "Master_Info_File": " ",
+                "Main_Server_Id": " 1",
+                "Main_UUID": " abc-cda ",
+                "Main_Info_File": " ",
                 "SQL_Delay": " 0",
                 "SQL_Remaining_Delay": " NULL",
-                "Slave_SQL_Running_State": " Reading event from the relay log",
-                "Master_Retry_Count": " 10",
-                "Master_Bind": "",
+                "Subordinate_SQL_Running_State": " Reading event from the relay log",
+                "Main_Retry_Count": " 10",
+                "Main_Bind": "",
                 "Last_IO_Error_Timestamp": "",
                 "Last_SQL_Error_Timestamp": "",
-                "Master_SSL_Crl": "",
-                "Master_SSL_Crlpath": "",
+                "Main_SSL_Crl": "",
+                "Main_SSL_Crlpath": "",
                 "Retrieved_Gtid_Set": " abc-cda ",
                 "Executed_Gtid_Set": " abc-cda ",
                 "Auto_Position": " 1",
                 "Replicate_Rewrite_DB": "",
                 "Channel_name": "",
-                "Master_TLS_Version": " TLSv1.2",
-                "Master_public_key_path": " xxx.yyy",
-                "Get_master_public_key": " 0"
+                "Main_TLS_Version": " TLSv1.2",
+                "Main_public_key_path": " xxx.yyy",
+                "Get_main_public_key": " 0"
             },
             "conslusion": "conslusion"
         })
@@ -536,9 +536,9 @@ class ApiMockController(BaseController):
                 "log_error": "/logs/xx/mysql-error.log",
                 "log_output": "FILE",
                 "log_queries_not_using_indexes": "ON",
-                "log_slave_updates": "OFF",
+                "log_subordinate_updates": "OFF",
                 "log_slow_admin_statements": "OFF",
-                "log_slow_slave_statements": "OFF",
+                "log_slow_subordinate_statements": "OFF",
                 "log_throttle_queries_not_using_indexes": "0",
                 "log_warnings": "1"
             }

--- a/core/models/replication.py
+++ b/core/models/replication.py
@@ -37,71 +37,71 @@ class MysqlReplication(BaseModel, ReplicationSql, Loggable):
             Dict[str, Any]: dict
         """
 
-        master_status = self.get_master_status()
-        slave_status = self.get_slave_status()
+        main_status = self.get_main_status()
+        subordinate_status = self.get_subordinate_status()
 
-        if master_status is None or slave_status is None:
+        if main_status is None or subordinate_status is None:
             return {}
 
         result: Dict[str, str] = {
-            "master_important_values": {},
-            "master_full_log": master_status,
-            "slave_important_values": {},
-            "slave_full_log": slave_status,
+            "main_important_values": {},
+            "main_full_log": main_status,
+            "subordinate_important_values": {},
+            "subordinate_full_log": subordinate_status,
             "conslusion": {}
         }
 
-        key_keys_slave = (
-            "Seconds_Behind_Master",
-            "Master_Log_File",
-            "Read_Master_Log_Pos",
+        key_keys_subordinate = (
+            "Seconds_Behind_Main",
+            "Main_Log_File",
+            "Read_Main_Log_Pos",
             "Relay_Log_File",
             "Relay_Log_Pos",
-            "Relay_Master_Log_File",
+            "Relay_Main_Log_File",
             "Last_Error",
             "Last_IO_Error",
             "Last_SQL_Error"
         )
 
-        key_keys_master = ("File", "Position")
+        key_keys_main = ("File", "Position")
 
-        for ik in key_keys_master:
-            if ik in master_status:
-                result["master_important_values"][ik] = master_status[ik]
+        for ik in key_keys_main:
+            if ik in main_status:
+                result["main_important_values"][ik] = main_status[ik]
 
-        for ik in key_keys_slave:
-            if ik in slave_status:
-                result["slave_important_values"][ik] = slave_status[ik]
+        for ik in key_keys_subordinate:
+            if ik in subordinate_status:
+                result["subordinate_important_values"][ik] = subordinate_status[ik]
 
         result["conslusion"] = "conslusion"
 
         return result
 
-    def get_master_status(self) -> Dict[str, str]:
+    def get_main_status(self) -> Dict[str, str]:
         """
-        get_master_status
+        get_main_status
 
         Returns:
             Dict[str, str]:
         """
 
         try:
-            result = self.db.fetchOne(self.get_master_status_sql, DSBFetchTypes.ASSOC)
+            result = self.db.fetchOne(self.get_main_status_sql, DSBFetchTypes.ASSOC)
             return result
         except Exception as e:
             log_objects(e)
             raise e
 
-    def get_slave_status(self) -> Dict[str, Any]:
+    def get_subordinate_status(self) -> Dict[str, Any]:
         """
-        get_slave_status
+        get_subordinate_status
 
         Returns:
             Dict[str, Any]: dict
         """
 
         try:
-            result = self.db.fetchOne(self.get_slave_status_sql, DSBFetchTypes.ASSOC)
+            result = self.db.fetchOne(self.get_subordinate_status_sql, DSBFetchTypes.ASSOC)
             return result
         except Exception as e:
             log_objects(e)

--- a/core/models/sql_traits/replication_sql.py
+++ b/core/models/sql_traits/replication_sql.py
@@ -4,9 +4,9 @@ from abc import ABC
 class ReplicationSql(ABC):
 
     @property
-    def get_master_status_sql(self) -> str:
+    def get_main_status_sql(self) -> str:
         """
-        get_master_status_sql
+        get_main_status_sql
 
         Returns:
             str: plain SQL
@@ -14,9 +14,9 @@ class ReplicationSql(ABC):
         return "SHOW MASTER STATUS"
 
     @property
-    def get_slave_status_sql(self) -> str:
+    def get_subordinate_status_sql(self) -> str:
         """
-        get_slave_status_sql
+        get_subordinate_status_sql
 
         Returns:
             str: plain SQL


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.